### PR TITLE
Fix summary report and prediction detail handling

### DIFF
--- a/src/atoms/csv-document.atom.ts
+++ b/src/atoms/csv-document.atom.ts
@@ -47,7 +47,7 @@ export const selectedDocumentLoadable = loadable(selectedDocumentAtom)
 export const recordsPageAtom = atom(1)
 export const recordsPageSizeAtom = atom(defaultPageSize)
 
-export const selectedCsvRecordsAtom: Atom<Promise<PaginationResultModel<CsvDocumentRecordModel>>> = atom(
+export const selectedCsvRecordsAtom1: Atom<Promise<PaginationResultModel<CsvDocumentRecordModel>>> = atom(
     get => {
         const id: string | undefined = get(selectedDocumentIdAtom)
         const page = get(recordsPageAtom)
@@ -63,7 +63,7 @@ export const selectedCsvRecordsAtom: Atom<Promise<PaginationResultModel<CsvDocum
         return service.listCsvDocumentRecords(id, {page, pageSize})
     }
 )
-export const selectedCsvRecordsLoadable = loadable(selectedCsvRecordsAtom)
+export const selectedCsvRecordsLoadable1 = loadable(selectedCsvRecordsAtom1)
 
 export const selectedCsvPredictionsAtom: Atom<Promise<CsvPredictionModel[]>> = atom(
     get => {

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -19,7 +19,7 @@ export const Pagination: React.FunctionComponent<PaginationProps> = ({page, page
     }
 
     const start = ((page - 1) * pageSize) + 1;
-    const end: number = (page * pageSize);
+    const end: number = Math.min((page * pageSize), totalCount);
     const totalText = totalCount ? ` of ${totalCount}` : '';
     const totalPages = totalCount ? ((totalCount / pageSize) + (totalCount % pageSize > 0 ? 1 : 0)) : Number.MAX_SAFE_INTEGER
 

--- a/src/models/csv-document.model.ts
+++ b/src/models/csv-document.model.ts
@@ -89,6 +89,7 @@ export interface CsvPredictionResultModel {
     predictionValue: string;
     confidence: number;
     agree: boolean;
+    data: Record;
 }
 
 // performance summary (e.g. number of agree/disagree, above/below confidence threshold

--- a/src/services/csv-document/csv-document.graphql.ts
+++ b/src/services/csv-document/csv-document.graphql.ts
@@ -3,7 +3,7 @@ import {ApolloClient, FetchResult} from "@apollo/client";
 
 import {CsvDocumentApi} from "./csv-document.api";
 import {
-    CsvDocumentRecordBackendModel,
+    CsvDocumentRecordBackendModel, CsvPredictionBackendResultModel,
     MUTATE_DELETE_DOCUMENT,
     MUTATION_CREATE_PREDICTION,
     QUERY_GET_DOCUMENT,
@@ -118,6 +118,7 @@ export class CsvDocumentGraphql implements CsvDocumentApi {
                 variables,
             })
             .then((result: FetchResult<ReturnTypeListPredictionRecords>) => result.data.listCsvPredictionRecords)
+            .then(backendPredictionRecordsToRecordModels)
     }
 
     observeCsvDocumentUpdates(): Observable<CsvDocumentModel> {
@@ -164,6 +165,26 @@ const backendRecordsToRecordModels = (records: PaginationResultModel<CsvDocument
 }
 
 const backendRecordToRecordModel = (record: CsvDocumentRecordBackendModel): CsvDocumentRecordModel => {
+    try {
+        const data: Record = JSON.parse(record.data)
+
+        return Object.assign({}, record, {data: Object.assign(data, {id: record.id, documentId: record.documentId})})
+    } catch (err) {
+        console.log('Error parsing JSON: ', err)
+    }
+
+    return Object.assign({}, record, {data: {id: record.id, documentId: record.documentId} as any})
+}
+
+
+const backendPredictionRecordsToRecordModels = (records: PaginationResultModel<CsvPredictionBackendResultModel>) => {
+    return {
+        metadata: records.metadata,
+        data: records.data.map(backendPredictionRecordToRecordModel)
+    }
+}
+
+const backendPredictionRecordToRecordModel = (record: CsvPredictionBackendResultModel): CsvPredictionResultModel => {
     try {
         const data: Record = JSON.parse(record.data)
 

--- a/src/services/csv-document/graphql.support.ts
+++ b/src/services/csv-document/graphql.support.ts
@@ -1,6 +1,6 @@
 import {gql} from "@apollo/client";
 
-import {CsvDocumentModel, CsvPredictionModel, CsvPredictionResultModel, PaginationResultModel} from "../../models";
+import {CsvDocumentModel, CsvPredictionModel, PaginationResultModel} from "../../models";
 
 export const QUERY_LIST_DOCUMENTS = gql`
     query ListCsvDocuments($pagination: PaginationInput, $status: CsvDocumentStatusFilter) {
@@ -92,6 +92,18 @@ export const QUERY_LIST_PREDICTIONS = gql`
 `
 export type ReturnTypeListPredictions = {listCsvPredictions: CsvPredictionModel[]}
 
+export interface CsvPredictionBackendResultModel {
+    id: string
+    documentId: string
+    predictionId: string
+    csvRecordId: string
+    providedValue: string
+    predictionValue: string
+    confidence: number
+    agree: boolean
+    data: string;
+}
+
 export const QUERY_LIST_PREDICTION_RECORDS = gql`
     query ListCsvPredictionRecords($predictionId: ID!, $pagination: PaginationInput, $options: CsvPredictionRecordOptions) {
         listCsvPredictionRecords(id: $predictionId, pagination: $pagination, options: $options) {
@@ -109,11 +121,12 @@ export const QUERY_LIST_PREDICTION_RECORDS = gql`
                 predictionValue
                 confidence
                 agree
+                data
             }
         }
     }
 `
-export type ReturnTypeListPredictionRecords = {listCsvPredictionRecords: PaginationResultModel<CsvPredictionResultModel>}
+export type ReturnTypeListPredictionRecords = {listCsvPredictionRecords: PaginationResultModel<CsvPredictionBackendResultModel>}
 
 export const MUTATION_CREATE_PREDICTION = gql`
     mutation CreateCsvPrediction($documentId: ID!) {

--- a/src/services/schema.gql
+++ b/src/services/schema.gql
@@ -80,6 +80,7 @@ type CsvPredictionResult {
   agree: Boolean
   confidence: Float!
   csvRecordId: String!
+  data: String
   documentId: String!
   id: ID!
   predictionId: String!

--- a/src/views/PerformanceSummaryView/PerformanceSummaryView.tsx
+++ b/src/views/PerformanceSummaryView/PerformanceSummaryView.tsx
@@ -18,6 +18,14 @@ export const PerformanceSummaryView: React.FunctionComponent<PerformanceSummaryV
     const disagreeAboveThresholdPercent = formatPercent(data.disagreeAboveThreshold, data.totalCount)
     const disagreeBelowThresholdPercent = formatPercent(data.disagreeBelowThreshold, data.totalCount)
 
+    if (data.agreeAboveThreshold === 0 && data.agreeBelowThreshold === 0) {
+        return (<div style={{display: 'grid', fontSize: 'small'}}>
+            <div style={{gridColumn: 1}}>&nbsp;</div><div style={{fontWeight: 'bold', textAlign: 'center', gridColumn: 2}}>Result</div><div style={{fontWeight: 'bold', textAlign: 'center', gridColumn: 3}}>Corr</div>
+            <div style={{gridColumn: 1, fontWeight: 'bold'}}>Above</div><div style={{gridColumn: 2, textAlign: 'center'}}>{data.disagreeAboveThreshold} {disagreeAboveThresholdPercent}</div><div style={{gridColumn: 3, textAlign: 'center', gridRowStart: 2, gridRowEnd: 3}}>{data.correctedRecords || 0}</div>
+            <div style={{gridColumn: 1, fontWeight: 'bold'}}>Below</div><div style={{gridColumn: 2, textAlign: 'center'}}>{data.disagreeBelowThreshold} {disagreeBelowThresholdPercent}</div>
+        </div>)
+    }
+
     return (<div style={{display: 'grid', fontSize: 'small'}}>
         <div style={{gridColumn: 1}}>&nbsp;</div><div style={{fontWeight: 'bold', gridColumn: 2, textAlign: 'center'}}>Agree</div><div style={{fontWeight: 'bold', textAlign: 'center', gridColumn: 3}}>Disagree</div><div style={{fontWeight: 'bold', textAlign: 'center', gridColumn: 4}}>Corr</div>
         <div style={{gridColumn: 1, fontWeight: 'bold'}}>Above</div><div style={{gridColumn: 2, textAlign: 'center'}}>{data.agreeAboveThreshold} {agreeAboveThresholdPercent}</div><div style={{gridColumn: 3, textAlign: 'center'}}>{data.disagreeAboveThreshold} {disagreeAboveThresholdPercent}</div><div style={{gridColumn: 4, textAlign: 'center', gridRowStart: 2, gridRowEnd: 3}}>{data.correctedRecords || 0}</div>


### PR DESCRIPTION
- Show only above and below threshold in summary report if comparison value is not provided
- Simplify prediction detail table to get details from prediction record instead of separate document record